### PR TITLE
appointment crud

### DIFF
--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/common/Address.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/common/Address.java
@@ -17,13 +17,12 @@ public class Address {
     @Column(nullable = false)
     private String city;
 
-    @NotBlank(message = "Town cannot be blank")
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String town;
 
-    @NotBlank(message = "Province cannot be blank")
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String province;
 
+    @Column(nullable = true)
     private String streetAddress;
 }

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/controller/AppointmentController.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/controller/AppointmentController.java
@@ -1,0 +1,105 @@
+package com.novaix.govconnect_server.controller;
+
+import com.novaix.govconnect_server.request.AppointmentActionRequestDTO;
+import com.novaix.govconnect_server.request.AppointmentRequestDTO;
+import com.novaix.govconnect_server.response.AppointmentResponseDTO;
+import com.novaix.govconnect_server.service.appointment.AppointmentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/appointments")
+@RequiredArgsConstructor
+@Slf4j
+public class AppointmentController {
+
+    private final AppointmentService appointmentService;
+
+    @PostMapping
+    public ResponseEntity<AppointmentResponseDTO> createAppointment(
+            @Valid @RequestBody AppointmentRequestDTO request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Create appointment request from user: {}", userDetails.getUsername());
+        AppointmentResponseDTO response = appointmentService.createAppointment(request, userDetails.getUsername());
+        return ResponseEntity.status(201).body(response);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<AppointmentResponseDTO>> getUserAppointments(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Get user appointments request from: {}", userDetails.getUsername());
+        List<AppointmentResponseDTO> appointments = appointmentService.getUserAppointments(userDetails.getUsername());
+        return ResponseEntity.ok(appointments);
+    }
+
+    @GetMapping("/assigned")
+    public ResponseEntity<List<AppointmentResponseDTO>> getOfficerAppointments(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Get officer appointments request from: {}", userDetails.getUsername());
+        List<AppointmentResponseDTO> appointments = appointmentService.getOfficerAppointments(userDetails.getUsername());
+        return ResponseEntity.ok(appointments);
+    }
+
+    @PutMapping("/{id}/accept")
+    public ResponseEntity<AppointmentResponseDTO> acceptAppointment(
+            @PathVariable String id,
+            @Valid @RequestBody AppointmentActionRequestDTO request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Accept appointment {} request from officer: {}", id, userDetails.getUsername());
+        AppointmentResponseDTO response = appointmentService.acceptAppointment(id, request, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}/reject")
+    public ResponseEntity<AppointmentResponseDTO> rejectAppointment(
+            @PathVariable String id,
+            @Valid @RequestBody AppointmentActionRequestDTO request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Reject appointment {} request from officer: {}", id, userDetails.getUsername());
+        AppointmentResponseDTO response = appointmentService.rejectAppointment(id, request, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AppointmentResponseDTO> getAppointmentById(
+            @PathVariable String id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Get appointment {} request from user: {}", id, userDetails.getUsername());
+        AppointmentResponseDTO response = appointmentService.getAppointmentById(id, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AppointmentResponseDTO> updateAppointment(
+            @PathVariable String id,
+            @Valid @RequestBody AppointmentRequestDTO request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Update appointment {} request from user: {}", id, userDetails.getUsername());
+        AppointmentResponseDTO response = appointmentService.updateAppointment(id, request, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> cancelAppointment(
+            @PathVariable String id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        log.info("Cancel appointment {} request from user: {}", id, userDetails.getUsername());
+        appointmentService.cancelAppointment(id, userDetails.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/AppointmentDao.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/AppointmentDao.java
@@ -1,0 +1,78 @@
+package com.novaix.govconnect_server.dao;
+
+import com.novaix.govconnect_server.common.BaseAuditingEntity;
+import com.novaix.govconnect_server.enums.AppointmentStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Entity
+@Table(name = "appointments")
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppointmentDao extends BaseAuditingEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UsersDao user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "officer_id", nullable = false)
+    private OfficerDao officer;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id", nullable = false)
+    private DepartmentDao department;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private TaskDao task;
+    
+    @Column(nullable = false)
+    private LocalDate appointmentDate;
+    
+    @Column(nullable = false)
+    private LocalTime startTime;
+    
+    @Column(nullable = false)
+    private LocalTime endTime;
+    
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AppointmentStatus status;
+    
+    @Column(nullable = false)
+    private boolean urgencyFlag = false;
+    
+    @Column
+    private String urgencyReason;
+    
+    @Column
+    private String rejectionReason;
+    
+    @Column
+    private String notes;
+    
+    @ElementCollection
+    @CollectionTable(name = "appointment_transfer_history", 
+                    joinColumns = @JoinColumn(name = "appointment_id"))
+    @Column(name = "transfer_note")
+    private List<String> transferHistory;
+    
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "appointment_additional_officers",
+        joinColumns = @JoinColumn(name = "appointment_id"),
+        inverseJoinColumns = @JoinColumn(name = "officer_id")
+    )
+    private List<OfficerDao> additionalOfficers;
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/DepartmentDao.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/DepartmentDao.java
@@ -1,0 +1,36 @@
+package com.novaix.govconnect_server.dao;
+
+import com.novaix.govconnect_server.common.BaseAuditingEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "departments")
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DepartmentDao extends BaseAuditingEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+    
+    @Column(nullable = false, unique = true)
+    private String name;
+    
+    @Column(nullable = false)
+    private String description;
+    
+    @Column(nullable = false)
+    private String location;
+    
+    @Column(nullable = false)
+    private String contactEmail;
+    
+    @Column(nullable = false)
+    private String contactPhone;
+    
+    @Column(nullable = false)
+    private boolean active = true;
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/OfficerDao.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/OfficerDao.java
@@ -1,0 +1,38 @@
+package com.novaix.govconnect_server.dao;
+
+import com.novaix.govconnect_server.common.BaseAuditingEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "officers")
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OfficerDao extends BaseAuditingEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+    
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private UsersDao user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id", nullable = false)
+    private DepartmentDao department;
+    
+    @Column(nullable = false)
+    private String position;
+    
+    @Column(nullable = false)
+    private String employeeId;
+    
+    @Column(nullable = false)
+    private boolean active = true;
+    
+    @Column
+    private String specialization;
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/TaskDao.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/dao/TaskDao.java
@@ -1,0 +1,53 @@
+package com.novaix.govconnect_server.dao;
+
+import com.novaix.govconnect_server.common.BaseAuditingEntity;
+import com.novaix.govconnect_server.enums.AppointmentStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "tasks")
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TaskDao extends BaseAuditingEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UsersDao user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id", nullable = false)
+    private DepartmentDao department;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_officer_id")
+    private OfficerDao assignedOfficer;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(nullable = false, length = 1000)
+    private String description;
+    
+    @Column(nullable = false)
+    private String taskType;
+    
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AppointmentStatus status;
+    
+    @Column(nullable = false)
+    private String priority;
+    
+    @Column
+    private String attachmentUrl;
+    
+    @Column
+    private String notes;
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/enums/AppointmentStatus.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/enums/AppointmentStatus.java
@@ -1,0 +1,11 @@
+package com.novaix.govconnect_server.enums;
+
+public enum AppointmentStatus {
+    BOOKED,
+    CONFIRMED,
+    COMPLETED,
+    CANCELLED,
+    REJECTED,
+    RESCHEDULED,
+    TRANSFERRED
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/AppointmentRepository.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/AppointmentRepository.java
@@ -1,0 +1,40 @@
+package com.novaix.govconnect_server.repository;
+
+import com.novaix.govconnect_server.dao.AppointmentDao;
+import com.novaix.govconnect_server.dao.OfficerDao;
+import com.novaix.govconnect_server.dao.UsersDao;
+import com.novaix.govconnect_server.enums.AppointmentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface AppointmentRepository extends JpaRepository<AppointmentDao, String> {
+    
+    List<AppointmentDao> findByUserOrderByAppointmentDateDesc(UsersDao user);
+    
+    List<AppointmentDao> findByOfficerOrderByAppointmentDateDesc(OfficerDao officer);
+    
+    List<AppointmentDao> findByUserAndStatus(UsersDao user, AppointmentStatus status);
+    
+    List<AppointmentDao> findByOfficerAndStatus(OfficerDao officer, AppointmentStatus status);
+    
+    @Query("SELECT a FROM AppointmentDao a WHERE a.appointmentDate = :date AND a.officer = :officer " +
+           "AND a.status NOT IN ('CANCELLED', 'REJECTED')")
+    List<AppointmentDao> findByDateAndOfficerAndNotCancelledOrRejected(
+        @Param("date") LocalDate date, 
+        @Param("officer") OfficerDao officer
+    );
+    
+    @Query("SELECT a FROM AppointmentDao a WHERE a.appointmentDate BETWEEN :startDate AND :endDate " +
+           "AND a.officer = :officer AND a.status NOT IN ('CANCELLED', 'REJECTED')")
+    List<AppointmentDao> findByDateRangeAndOfficerAndNotCancelledOrRejected(
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate,
+        @Param("officer") OfficerDao officer
+    );
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/DepartmentRepository.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/DepartmentRepository.java
@@ -1,0 +1,18 @@
+package com.novaix.govconnect_server.repository;
+
+import com.novaix.govconnect_server.dao.DepartmentDao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<DepartmentDao, String> {
+    
+    Optional<DepartmentDao> findByName(String name);
+    
+    List<DepartmentDao> findByActiveTrue();
+    
+    boolean existsByName(String name);
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/OfficerRepository.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/OfficerRepository.java
@@ -1,0 +1,22 @@
+package com.novaix.govconnect_server.repository;
+
+import com.novaix.govconnect_server.dao.DepartmentDao;
+import com.novaix.govconnect_server.dao.OfficerDao;
+import com.novaix.govconnect_server.dao.UsersDao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OfficerRepository extends JpaRepository<OfficerDao, String> {
+    
+    Optional<OfficerDao> findByUser(UsersDao user);
+    
+    List<OfficerDao> findByDepartmentAndActiveTrue(DepartmentDao department);
+    
+    List<OfficerDao> findByActiveTrue();
+    
+    boolean existsByEmployeeId(String employeeId);
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/TaskRepository.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/repository/TaskRepository.java
@@ -1,0 +1,25 @@
+package com.novaix.govconnect_server.repository;
+
+import com.novaix.govconnect_server.dao.DepartmentDao;
+import com.novaix.govconnect_server.dao.OfficerDao;
+import com.novaix.govconnect_server.dao.TaskDao;
+import com.novaix.govconnect_server.dao.UsersDao;
+import com.novaix.govconnect_server.enums.AppointmentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TaskRepository extends JpaRepository<TaskDao, String> {
+    
+    List<TaskDao> findByUserOrderByCreatedDateDesc(UsersDao user);
+    
+    List<TaskDao> findByAssignedOfficerOrderByCreatedDateDesc(OfficerDao officer);
+    
+    List<TaskDao> findByDepartmentOrderByCreatedDateDesc(DepartmentDao department);
+    
+    List<TaskDao> findByStatus(AppointmentStatus status);
+    
+    List<TaskDao> findByUserAndStatus(UsersDao user, AppointmentStatus status);
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/request/AppointmentActionRequestDTO.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/request/AppointmentActionRequestDTO.java
@@ -1,0 +1,18 @@
+package com.novaix.govconnect_server.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppointmentActionRequestDTO {
+    
+    @Size(max = 1000, message = "Notes cannot exceed 1000 characters")
+    private String notes;
+    
+    @Size(max = 500, message = "Reason cannot exceed 500 characters")
+    private String reason;
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/request/AppointmentRequestDTO.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/request/AppointmentRequestDTO.java
@@ -1,0 +1,46 @@
+package com.novaix.govconnect_server.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppointmentRequestDTO {
+    
+    @NotBlank(message = "Task ID is required")
+    private String taskId;
+    
+    @NotBlank(message = "Officer ID is required")
+    private String officerId;
+    
+    @NotBlank(message = "Department ID is required")
+    private String departmentId;
+    
+    @NotNull(message = "Appointment date is required")
+    @Future(message = "Appointment date must be in the future")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate appointmentDate;
+    
+    @NotNull(message = "Start time is required")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime startTime;
+    
+    @NotNull(message = "End time is required")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime endTime;
+    
+    private boolean urgencyFlag = false;
+    
+    @Size(max = 500, message = "Urgency reason cannot exceed 500 characters")
+    private String urgencyReason;
+    
+    @Size(max = 1000, message = "Notes cannot exceed 1000 characters")
+    private String notes;
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/response/AppointmentResponseDTO.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/response/AppointmentResponseDTO.java
@@ -1,0 +1,118 @@
+package com.novaix.govconnect_server.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.novaix.govconnect_server.enums.AppointmentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppointmentResponseDTO {
+    
+    @JsonProperty(index = 1)
+    private String id;
+    
+    @JsonProperty(index = 2)
+    private UserBasicInfo user;
+    
+    @JsonProperty(index = 3)
+    private OfficerBasicInfo officer;
+    
+    @JsonProperty(index = 4)
+    private DepartmentBasicInfo department;
+    
+    @JsonProperty(index = 5)
+    private TaskBasicInfo task;
+    
+    @JsonProperty(index = 6)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate appointmentDate;
+    
+    @JsonProperty(index = 7)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime startTime;
+    
+    @JsonProperty(index = 8)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime endTime;
+    
+    @JsonProperty(index = 9)
+    private AppointmentStatus status;
+    
+    @JsonProperty(index = 10)
+    private boolean urgencyFlag;
+    
+    @JsonProperty(index = 11)
+    private String urgencyReason;
+    
+    @JsonProperty(index = 12)
+    private String rejectionReason;
+    
+    @JsonProperty(index = 13)
+    private String notes;
+    
+    @JsonProperty(index = 14)
+    private List<String> transferHistory;
+    
+    @JsonProperty(index = 15)
+    private List<OfficerBasicInfo> additionalOfficers;
+    
+    @JsonProperty(index = 16)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+    
+    @JsonProperty(index = 17)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime lastModifiedDate;
+    
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserBasicInfo {
+        private Long id;
+        private String firstname;
+        private String lastname;
+        private String email;
+        private String contact;
+    }
+    
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class OfficerBasicInfo {
+        private String id;
+        private String position;
+        private String employeeId;
+        private UserBasicInfo user;
+    }
+    
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DepartmentBasicInfo {
+        private String id;
+        private String name;
+        private String location;
+        private String contactEmail;
+        private String contactPhone;
+    }
+    
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TaskBasicInfo {
+        private String id;
+        private String title;
+        private String taskType;
+        private String priority;
+        private AppointmentStatus status;
+    }
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/service/appointment/AppointmentService.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/service/appointment/AppointmentService.java
@@ -1,0 +1,21 @@
+package com.novaix.govconnect_server.service.appointment;
+
+import com.novaix.govconnect_server.request.AppointmentActionRequestDTO;
+import com.novaix.govconnect_server.request.AppointmentRequestDTO;
+import com.novaix.govconnect_server.response.AppointmentResponseDTO;
+
+import java.util.List;
+
+public interface AppointmentService {
+    
+    AppointmentResponseDTO createAppointment(AppointmentRequestDTO request, String authenticatedUserEmail);
+    List<AppointmentResponseDTO> getUserAppointments(String authenticatedUserEmail);
+    
+    List<AppointmentResponseDTO> getOfficerAppointments(String authenticatedUserEmail);
+    AppointmentResponseDTO acceptAppointment(String appointmentId, AppointmentActionRequestDTO request, String authenticatedUserEmail);
+    AppointmentResponseDTO rejectAppointment(String appointmentId, AppointmentActionRequestDTO request, String authenticatedUserEmail);
+    
+    AppointmentResponseDTO getAppointmentById(String appointmentId, String authenticatedUserEmail);
+    AppointmentResponseDTO updateAppointment(String appointmentId, AppointmentRequestDTO request, String authenticatedUserEmail);
+    void cancelAppointment(String appointmentId, String authenticatedUserEmail);
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/service/appointment/impl/AppointmentServiceImpl.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/service/appointment/impl/AppointmentServiceImpl.java
@@ -1,0 +1,438 @@
+package com.novaix.govconnect_server.service.appointment.impl;
+
+import com.novaix.govconnect_server.dao.AppointmentDao;
+import com.novaix.govconnect_server.dao.DepartmentDao;
+import com.novaix.govconnect_server.dao.OfficerDao;
+import com.novaix.govconnect_server.dao.TaskDao;
+import com.novaix.govconnect_server.dao.UsersDao;
+import com.novaix.govconnect_server.enums.AppointmentStatus;
+import com.novaix.govconnect_server.enums.Role;
+import com.novaix.govconnect_server.exception.custom.ForbiddenException;
+import com.novaix.govconnect_server.exception.custom.InvalidInputException;
+import com.novaix.govconnect_server.exception.custom.ResourceNotFoundException;
+import com.novaix.govconnect_server.repository.AppointmentRepository;
+import com.novaix.govconnect_server.repository.DepartmentRepository;
+import com.novaix.govconnect_server.repository.OfficerRepository;
+import com.novaix.govconnect_server.repository.TaskRepository;
+import com.novaix.govconnect_server.repository.UserRepository;
+import com.novaix.govconnect_server.request.AppointmentActionRequestDTO;
+import com.novaix.govconnect_server.request.AppointmentRequestDTO;
+import com.novaix.govconnect_server.response.AppointmentResponseDTO;
+import com.novaix.govconnect_server.service.appointment.AppointmentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class AppointmentServiceImpl implements AppointmentService {
+    
+    private final AppointmentRepository appointmentRepository;
+    private final UserRepository userRepository;
+    private final OfficerRepository officerRepository;
+    private final DepartmentRepository departmentRepository;
+    private final TaskRepository taskRepository;
+    
+    @Override
+    public AppointmentResponseDTO createAppointment(AppointmentRequestDTO request, String authenticatedUserEmail) {
+        log.info("Creating appointment for user: {}", authenticatedUserEmail);
+        
+        UsersDao user = getUserByEmail(authenticatedUserEmail);
+        
+        if (user.getRole() != Role.ROLE_USER) {
+            throw new ForbiddenException("Only users can create appointments");
+        }
+        
+        TaskDao task = getTaskById(request.getTaskId());
+        OfficerDao officer = getOfficerById(request.getOfficerId());
+        DepartmentDao department = getDepartmentById(request.getDepartmentId());
+        
+        if (!task.getUser().getId().equals(user.getId())) {
+            throw new ForbiddenException("You can only create appointments for your own tasks");
+        }
+        
+        validateAppointmentTime(request.getAppointmentDate(), request.getStartTime(), request.getEndTime());
+        
+        validateTimeConflicts(officer, request.getAppointmentDate(), request.getStartTime(), request.getEndTime());
+        
+        AppointmentDao appointment = new AppointmentDao();
+        appointment.setUser(user);
+        appointment.setOfficer(officer);
+        appointment.setDepartment(department);
+        appointment.setTask(task);
+        appointment.setAppointmentDate(request.getAppointmentDate());
+        appointment.setStartTime(request.getStartTime());
+        appointment.setEndTime(request.getEndTime());
+        appointment.setStatus(AppointmentStatus.BOOKED);
+        appointment.setUrgencyFlag(request.isUrgencyFlag());
+        appointment.setUrgencyReason(request.getUrgencyReason());
+        appointment.setNotes(request.getNotes());
+        appointment.setTransferHistory(new ArrayList<>());
+        appointment.setAdditionalOfficers(new ArrayList<>());
+        
+        AppointmentDao savedAppointment = appointmentRepository.save(appointment);
+        log.info("Appointment created successfully with ID: {}", savedAppointment.getId());
+        
+        return mapToResponseDTO(savedAppointment);
+    }
+    
+    @Override
+    public List<AppointmentResponseDTO> getUserAppointments(String authenticatedUserEmail) {
+        log.info("Fetching appointments for user: {}", authenticatedUserEmail);
+        
+        UsersDao user = getUserByEmail(authenticatedUserEmail);
+        
+        if (user.getRole() != Role.ROLE_USER) {
+            throw new ForbiddenException("Only users can view their own appointments");
+        }
+        
+        List<AppointmentDao> appointments = appointmentRepository.findByUserOrderByAppointmentDateDesc(user);
+        return appointments.stream()
+                .map(this::mapToResponseDTO)
+                .toList();
+    }
+    
+    @Override
+    public List<AppointmentResponseDTO> getOfficerAppointments(String authenticatedUserEmail) {
+        log.info("Fetching appointments for officer: {}", authenticatedUserEmail);
+        
+        UsersDao user = getUserByEmail(authenticatedUserEmail);
+        
+        if (user.getRole() != Role.ROLE_ADMIN) {
+            throw new ForbiddenException("Only officers can view assigned appointments");
+        }
+        
+        Optional<OfficerDao> officerOpt = officerRepository.findByUser(user);
+        if (officerOpt.isEmpty()) {
+            throw new ResourceNotFoundException("Officer profile not found for user: " + authenticatedUserEmail);
+        }
+        
+        OfficerDao officer = officerOpt.get();
+        List<AppointmentDao> appointments = appointmentRepository.findByOfficerOrderByAppointmentDateDesc(officer);
+        return appointments.stream()
+                .map(this::mapToResponseDTO)
+                .toList();
+    }
+    
+    @Override
+    public AppointmentResponseDTO acceptAppointment(String appointmentId, AppointmentActionRequestDTO request, String authenticatedUserEmail) {
+        log.info("Officer {} accepting appointment {}", authenticatedUserEmail, appointmentId);
+        
+        AppointmentDao appointment = getAppointmentById(appointmentId);
+        OfficerDao officer = getOfficerByEmail(authenticatedUserEmail);
+        
+        if (!appointment.getOfficer().getId().equals(officer.getId())) {
+            throw new ForbiddenException("You can only accept appointments assigned to you");
+        }
+        
+        if (appointment.getStatus() != AppointmentStatus.BOOKED) {
+            throw new InvalidInputException("Only booked appointments can be accepted");
+        }
+        
+        appointment.setStatus(AppointmentStatus.CONFIRMED);
+        if (request.getNotes() != null && !request.getNotes().trim().isEmpty()) {
+            appointment.setNotes(appointment.getNotes() + "\n[Officer Acceptance]: " + request.getNotes());
+        }
+        
+        AppointmentDao savedAppointment = appointmentRepository.save(appointment);
+        log.info("Appointment {} accepted successfully", appointmentId);
+        
+        return mapToResponseDTO(savedAppointment);
+    }
+    
+    @Override
+    public AppointmentResponseDTO rejectAppointment(String appointmentId, AppointmentActionRequestDTO request, String authenticatedUserEmail) {
+        log.info("Officer {} rejecting appointment {}", authenticatedUserEmail, appointmentId);
+        
+        AppointmentDao appointment = getAppointmentById(appointmentId);
+        OfficerDao officer = getOfficerByEmail(authenticatedUserEmail);
+        
+        if (!appointment.getOfficer().getId().equals(officer.getId())) {
+            throw new ForbiddenException("You can only reject appointments assigned to you");
+        }
+        
+        if (appointment.getStatus() == AppointmentStatus.COMPLETED || appointment.getStatus() == AppointmentStatus.CANCELLED) {
+            throw new InvalidInputException("Cannot reject completed or cancelled appointments");
+        }
+        
+        appointment.setStatus(AppointmentStatus.REJECTED);
+        appointment.setRejectionReason(request.getReason());
+        if (request.getNotes() != null && !request.getNotes().trim().isEmpty()) {
+            appointment.setNotes(appointment.getNotes() + "\n[Officer Rejection]: " + request.getNotes());
+        }
+        
+        AppointmentDao savedAppointment = appointmentRepository.save(appointment);
+        log.info("Appointment {} rejected successfully", appointmentId);
+        
+        return mapToResponseDTO(savedAppointment);
+    }
+    
+    @Override
+    public AppointmentResponseDTO getAppointmentById(String appointmentId, String authenticatedUserEmail) {
+        log.info("Fetching appointment {} for user {}", appointmentId, authenticatedUserEmail);
+        
+        AppointmentDao appointment = getAppointmentById(appointmentId);
+        UsersDao user = getUserByEmail(authenticatedUserEmail);
+        
+        validateAppointmentAccess(appointment, user);
+        
+        return mapToResponseDTO(appointment);
+    }
+    
+    @Override
+    public AppointmentResponseDTO updateAppointment(String appointmentId, AppointmentRequestDTO request, String authenticatedUserEmail) {
+        log.info("Updating appointment {} by user {}", appointmentId, authenticatedUserEmail);
+        
+        AppointmentDao appointment = getAppointmentById(appointmentId);
+        UsersDao user = getUserByEmail(authenticatedUserEmail);
+        
+        if (!appointment.getUser().getId().equals(user.getId())) {
+            throw new ForbiddenException("You can only update your own appointments");
+        }
+        
+        if (appointment.getStatus() != AppointmentStatus.BOOKED) {
+            throw new InvalidInputException("Only booked appointments can be updated");
+        }
+        
+        if (!appointment.getAppointmentDate().equals(request.getAppointmentDate()) ||
+            !appointment.getStartTime().equals(request.getStartTime()) ||
+            !appointment.getEndTime().equals(request.getEndTime())) {
+            
+            validateAppointmentTime(request.getAppointmentDate(), request.getStartTime(), request.getEndTime());
+            validateTimeConflicts(appointment.getOfficer(), request.getAppointmentDate(), 
+                                request.getStartTime(), request.getEndTime(), appointmentId);
+        }
+        
+        appointment.setAppointmentDate(request.getAppointmentDate());
+        appointment.setStartTime(request.getStartTime());
+        appointment.setEndTime(request.getEndTime());
+        appointment.setUrgencyFlag(request.isUrgencyFlag());
+        appointment.setUrgencyReason(request.getUrgencyReason());
+        appointment.setNotes(request.getNotes());
+        appointment.setStatus(AppointmentStatus.RESCHEDULED);
+        
+        AppointmentDao savedAppointment = appointmentRepository.save(appointment);
+        log.info("Appointment {} updated successfully", appointmentId);
+        
+        return mapToResponseDTO(savedAppointment);
+    }
+    
+    @Override
+    public void cancelAppointment(String appointmentId, String authenticatedUserEmail) {
+        log.info("Cancelling appointment {} by user {}", appointmentId, authenticatedUserEmail);
+        
+        AppointmentDao appointment = getAppointmentById(appointmentId);
+        UsersDao user = getUserByEmail(authenticatedUserEmail);
+        
+        if (!appointment.getUser().getId().equals(user.getId())) {
+            throw new ForbiddenException("You can only cancel your own appointments");
+        }
+        
+        if (appointment.getStatus() == AppointmentStatus.COMPLETED) {
+            throw new InvalidInputException("Cannot cancel completed appointments");
+        }
+        
+        appointment.setStatus(AppointmentStatus.CANCELLED);
+        appointmentRepository.save(appointment);
+        log.info("Appointment {} cancelled successfully", appointmentId);
+    }
+    
+    private UsersDao getUserByEmail(String email) {
+        UsersDao user = userRepository.findByEmail(email);
+        if (user == null) {
+            throw new ResourceNotFoundException("User not found with email: " + email);
+        }
+        return user;
+    }
+    
+    private OfficerDao getOfficerByEmail(String email) {
+        UsersDao user = getUserByEmail(email);
+        if (user.getRole() != Role.ROLE_ADMIN) {
+            throw new ForbiddenException("User is not an officer");
+        }
+        
+        Optional<OfficerDao> officerOpt = officerRepository.findByUser(user);
+        if (officerOpt.isEmpty()) {
+            throw new ResourceNotFoundException("Officer profile not found for user: " + email);
+        }
+        return officerOpt.get();
+    }
+    
+    private AppointmentDao getAppointmentById(String appointmentId) {
+        Optional<AppointmentDao> appointmentOpt = appointmentRepository.findById(appointmentId);
+        if (appointmentOpt.isEmpty()) {
+            throw new ResourceNotFoundException("Appointment not found with ID: " + appointmentId);
+        }
+        return appointmentOpt.get();
+    }
+    
+    private TaskDao getTaskById(String taskId) {
+        Optional<TaskDao> taskOpt = taskRepository.findById(taskId);
+        if (taskOpt.isEmpty()) {
+            throw new ResourceNotFoundException("Task not found with ID: " + taskId);
+        }
+        return taskOpt.get();
+    }
+    
+    private OfficerDao getOfficerById(String officerId) {
+        Optional<OfficerDao> officerOpt = officerRepository.findById(officerId);
+        if (officerOpt.isEmpty()) {
+            throw new ResourceNotFoundException("Officer not found with ID: " + officerId);
+        }
+        return officerOpt.get();
+    }
+    
+    private DepartmentDao getDepartmentById(String departmentId) {
+        Optional<DepartmentDao> departmentOpt = departmentRepository.findById(departmentId);
+        if (departmentOpt.isEmpty()) {
+            throw new ResourceNotFoundException("Department not found with ID: " + departmentId);
+        }
+        return departmentOpt.get();
+    }
+    
+    private void validateAppointmentTime(LocalDate appointmentDate, LocalTime startTime, LocalTime endTime) {
+        if (appointmentDate.isBefore(LocalDate.now()) || 
+            (appointmentDate.equals(LocalDate.now()) && startTime.isBefore(LocalTime.now()))) {
+            throw new InvalidInputException("Appointment must be scheduled for a future date and time");
+        }
+        
+        if (!endTime.isAfter(startTime)) {
+            throw new InvalidInputException("End time must be after start time");
+        }
+        
+        if (startTime.isBefore(LocalTime.of(9, 0)) || endTime.isAfter(LocalTime.of(17, 0))) {
+            throw new InvalidInputException("Appointments must be scheduled between 9:00 AM and 5:00 PM");
+        }
+    }
+    
+    private void validateTimeConflicts(OfficerDao officer, LocalDate appointmentDate, 
+                                     LocalTime startTime, LocalTime endTime) {
+        validateTimeConflicts(officer, appointmentDate, startTime, endTime, null);
+    }
+    
+    private void validateTimeConflicts(OfficerDao officer, LocalDate appointmentDate, 
+                                     LocalTime startTime, LocalTime endTime, String excludeAppointmentId) {
+        List<AppointmentDao> existingAppointments = appointmentRepository
+                .findByDateAndOfficerAndNotCancelledOrRejected(appointmentDate, officer);
+        
+        for (AppointmentDao existing : existingAppointments) {
+            if (excludeAppointmentId != null && existing.getId().equals(excludeAppointmentId)) {
+                continue;
+            }
+            
+            if (!(endTime.isBefore(existing.getStartTime()) || startTime.isAfter(existing.getEndTime()))) {
+                throw new InvalidInputException("The requested time slot conflicts with an existing appointment");
+            }
+        }
+    }
+    
+    private void validateAppointmentAccess(AppointmentDao appointment, UsersDao user) {
+        if (appointment.getUser().getId().equals(user.getId())) {
+            return;
+        }
+        
+        if (user.getRole() == Role.ROLE_ADMIN) {
+            Optional<OfficerDao> officerOpt = officerRepository.findByUser(user);
+            if (officerOpt.isPresent() && appointment.getOfficer().getId().equals(officerOpt.get().getId())) {
+                return;
+            }
+        }
+        
+        if (user.getRole() == Role.ROLE_SUPERADMIN) {
+            return;
+        }
+        
+        throw new ForbiddenException("You don't have permission to access this appointment");
+    }
+    
+    private AppointmentResponseDTO mapToResponseDTO(AppointmentDao appointment) {
+        AppointmentResponseDTO response = new AppointmentResponseDTO();
+        
+        response.setId(appointment.getId());
+        response.setAppointmentDate(appointment.getAppointmentDate());
+        response.setStartTime(appointment.getStartTime());
+        response.setEndTime(appointment.getEndTime());
+        response.setStatus(appointment.getStatus());
+        response.setUrgencyFlag(appointment.isUrgencyFlag());
+        response.setUrgencyReason(appointment.getUrgencyReason());
+        response.setRejectionReason(appointment.getRejectionReason());
+        response.setNotes(appointment.getNotes());
+        response.setTransferHistory(appointment.getTransferHistory());
+        response.setCreatedDate(appointment.getCreatedDate());
+        response.setLastModifiedDate(appointment.getLastModifiedDate());
+        
+        UsersDao user = appointment.getUser();
+        AppointmentResponseDTO.UserBasicInfo userInfo = new AppointmentResponseDTO.UserBasicInfo();
+        userInfo.setId(user.getId());
+        userInfo.setFirstname(user.getFirstname());
+        userInfo.setLastname(user.getLastname());
+        userInfo.setEmail(user.getEmail());
+        userInfo.setContact(user.getContact());
+        response.setUser(userInfo);
+        
+        OfficerDao officer = appointment.getOfficer();
+        AppointmentResponseDTO.OfficerBasicInfo officerInfo = new AppointmentResponseDTO.OfficerBasicInfo();
+        officerInfo.setId(officer.getId());
+        officerInfo.setPosition(officer.getPosition());
+        officerInfo.setEmployeeId(officer.getEmployeeId());
+        
+        AppointmentResponseDTO.UserBasicInfo officerUserInfo = new AppointmentResponseDTO.UserBasicInfo();
+        officerUserInfo.setId(officer.getUser().getId());
+        officerUserInfo.setFirstname(officer.getUser().getFirstname());
+        officerUserInfo.setLastname(officer.getUser().getLastname());
+        officerUserInfo.setEmail(officer.getUser().getEmail());
+        officerUserInfo.setContact(officer.getUser().getContact());
+        officerInfo.setUser(officerUserInfo);
+        response.setOfficer(officerInfo);
+        
+        DepartmentDao department = appointment.getDepartment();
+        AppointmentResponseDTO.DepartmentBasicInfo departmentInfo = new AppointmentResponseDTO.DepartmentBasicInfo();
+        departmentInfo.setId(department.getId());
+        departmentInfo.setName(department.getName());
+        departmentInfo.setLocation(department.getLocation());
+        departmentInfo.setContactEmail(department.getContactEmail());
+        departmentInfo.setContactPhone(department.getContactPhone());
+        response.setDepartment(departmentInfo);
+        
+        TaskDao task = appointment.getTask();
+        AppointmentResponseDTO.TaskBasicInfo taskInfo = new AppointmentResponseDTO.TaskBasicInfo();
+        taskInfo.setId(task.getId());
+        taskInfo.setTitle(task.getTitle());
+        taskInfo.setTaskType(task.getTaskType());
+        taskInfo.setPriority(task.getPriority());
+        taskInfo.setStatus(task.getStatus());
+        response.setTask(taskInfo);
+        
+        if (appointment.getAdditionalOfficers() != null) {
+            List<AppointmentResponseDTO.OfficerBasicInfo> additionalOfficers = new ArrayList<>();
+            for (OfficerDao additionalOfficer : appointment.getAdditionalOfficers()) {
+                AppointmentResponseDTO.OfficerBasicInfo additionalInfo = new AppointmentResponseDTO.OfficerBasicInfo();
+                additionalInfo.setId(additionalOfficer.getId());
+                additionalInfo.setPosition(additionalOfficer.getPosition());
+                additionalInfo.setEmployeeId(additionalOfficer.getEmployeeId());
+                
+                AppointmentResponseDTO.UserBasicInfo additionalUserInfo = new AppointmentResponseDTO.UserBasicInfo();
+                additionalUserInfo.setId(additionalOfficer.getUser().getId());
+                additionalUserInfo.setFirstname(additionalOfficer.getUser().getFirstname());
+                additionalUserInfo.setLastname(additionalOfficer.getUser().getLastname());
+                additionalUserInfo.setEmail(additionalOfficer.getUser().getEmail());
+                additionalUserInfo.setContact(additionalOfficer.getUser().getContact());
+                additionalInfo.setUser(additionalUserInfo);
+                
+                additionalOfficers.add(additionalInfo);
+            }
+            response.setAdditionalOfficers(additionalOfficers);
+        }
+        
+        return response;
+    }
+}

--- a/govconnect-server/src/main/java/com/novaix/govconnect_server/service/user/impl/UserServiceImpl.java
+++ b/govconnect-server/src/main/java/com/novaix/govconnect_server/service/user/impl/UserServiceImpl.java
@@ -32,7 +32,6 @@ public class UserServiceImpl implements UserService {
     public UserUpdateResponse updateUser(Long userId, UserUpdateRequest request, String authenticatedUserEmail) {
         log.info("Attempting to update user with ID: {} by authenticated user: {}", userId, authenticatedUserEmail);
         
-        // Find the user to be updated
         Optional<UsersDao> userOptional = userRepository.findById(userId);
         if (userOptional.isEmpty()) {
             log.error("User not found with ID: {}", userId);
@@ -41,26 +40,22 @@ public class UserServiceImpl implements UserService {
         
         UsersDao userToUpdate = userOptional.get();
         
-        // Security check: Only allow users to update their own profile
         if (!userToUpdate.getEmail().equals(authenticatedUserEmail)) {
             log.error("User {} attempted to update user {} profile. Access denied.", 
                      authenticatedUserEmail, userToUpdate.getEmail());
             throw new ForbiddenException("You can only update your own profile");
         }
         
-        // Validate phone number format if provided
         if (request.getPhoneNumber() != null && !request.getPhoneNumber().matches(PHONE_NUMBER_PATTERN)) {
             throw new InvalidInputException("Phone number must be 10 digits long");
         }
         
-        // Validate date of birth if provided
         if (request.getDob() != null) {
             if (request.getDob().isAfter(LocalDate.now().minusYears(18))) {
                 throw new InvalidInputException("You must be at least 18 years old");
             }
         }
         
-        // Update allowed fields only
         if (request.getFirstName() != null && !request.getFirstName().trim().isEmpty()) {
             userToUpdate.setFirstname(request.getFirstName().trim());
         }
@@ -81,14 +76,11 @@ public class UserServiceImpl implements UserService {
             userToUpdate.setDob(request.getDob());
         }
         
-        // Save updated user
         UsersDao updatedUser = userRepository.save(userToUpdate);
         log.info("Successfully updated user with ID: {}", userId);
         
-        // Map to response DTO
         UserUpdateResponse response = modelMapper.map(updatedUser, UserUpdateResponse.class);
         
-        // Ensure correct field mapping from entity to response
         response.setPhoneNumber(updatedUser.getContact());
         response.setFirstName(updatedUser.getFirstname());
         response.setLastName(updatedUser.getLastname());

--- a/govconnect-server/src/test/java/com/novaix/govconnect_server/service/user/UserServiceTest.java
+++ b/govconnect-server/src/test/java/com/novaix/govconnect_server/service/user/UserServiceTest.java
@@ -45,7 +45,6 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        // Create test user
         testUser = new UsersDao();
         testUser.setId(1L);
         testUser.setFirstname("John");
@@ -61,7 +60,6 @@ class UserServiceTest {
         Address address = new Address("Colombo", "Mount Lavinia", "Western", "123 Main St");
         testUser.setAddress(address);
 
-        // Create update request
         updateRequest = new UserUpdateRequest();
         updateRequest.setFirstName("Jane");
         updateRequest.setLastName("Smith");
@@ -71,7 +69,6 @@ class UserServiceTest {
         Address newAddress = new Address("Kandy", "Peradeniya", "Central", "456 New St");
         updateRequest.setAddress(newAddress);
 
-        // Create update response
         updateResponse = new UserUpdateResponse();
         updateResponse.setId(1L);
         updateResponse.setFirstName("Jane");
@@ -88,15 +85,12 @@ class UserServiceTest {
 
     @Test
     void testUpdateUser_Success() {
-        // Given
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
         when(userRepository.save(any(UsersDao.class))).thenReturn(testUser);
         when(modelMapper.map(any(UsersDao.class), eq(UserUpdateResponse.class))).thenReturn(updateResponse);
 
-        // When
         UserUpdateResponse result = userService.updateUser(1L, updateRequest, "john.doe@example.com");
 
-        // Then
         assertNotNull(result);
         assertEquals("Jane", result.getFirstName());
         assertEquals("Smith", result.getLastName());
@@ -109,10 +103,8 @@ class UserServiceTest {
 
     @Test
     void testUpdateUser_UserNotFound() {
-        // Given
         when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
-        // When & Then
         assertThrows(ResourceNotFoundException.class, () -> {
             userService.updateUser(1L, updateRequest, "john.doe@example.com");
         });
@@ -123,10 +115,8 @@ class UserServiceTest {
 
     @Test
     void testUpdateUser_ForbiddenAccess() {
-        // Given
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
-        // When & Then
         assertThrows(ForbiddenException.class, () -> {
             userService.updateUser(1L, updateRequest, "different.user@example.com");
         });
@@ -137,11 +127,9 @@ class UserServiceTest {
 
     @Test
     void testUpdateUser_InvalidPhoneNumber() {
-        // Given
         updateRequest.setPhoneNumber("invalid");
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
-        // When & Then
         assertThrows(com.novaix.govconnect_server.exception.custom.InvalidInputException.class, () -> {
             userService.updateUser(1L, updateRequest, "john.doe@example.com");
         });
@@ -152,7 +140,6 @@ class UserServiceTest {
 
     @Test
     void testUpdateUser_WithDateOfBirth() {
-        // Given
         LocalDate newDob = LocalDate.of(1995, 12, 25);
         updateRequest.setDob(newDob);
         
@@ -160,10 +147,8 @@ class UserServiceTest {
         when(userRepository.save(any(UsersDao.class))).thenReturn(testUser);
         when(modelMapper.map(any(UsersDao.class), eq(UserUpdateResponse.class))).thenReturn(updateResponse);
 
-        // When
         UserUpdateResponse result = userService.updateUser(1L, updateRequest, "john.doe@example.com");
 
-        // Then
         assertNotNull(result);
         verify(userRepository).findById(1L);
         verify(userRepository).save(any(UsersDao.class));
@@ -172,12 +157,10 @@ class UserServiceTest {
 
     @Test
     void testUpdateUser_InvalidDateOfBirth_TooYoung() {
-        // Given
-        LocalDate invalidDob = LocalDate.now().minusYears(17); // Less than 18 years old
+        LocalDate invalidDob = LocalDate.now().minusYears(17);
         updateRequest.setDob(invalidDob);
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
-        // When & Then
         assertThrows(com.novaix.govconnect_server.exception.custom.InvalidInputException.class, () -> {
             userService.updateUser(1L, updateRequest, "john.doe@example.com");
         });


### PR DESCRIPTION
This pull request introduces a comprehensive appointment management feature to the backend, including new entities, repositories, request/response DTOs, and a REST controller for handling appointment-related operations. The changes are grouped below by theme for clarity.

**Appointment Management Features**

* Added `AppointmentController` with endpoints for creating, updating, viewing, accepting, rejecting, and canceling appointments, supporting user and officer workflows.
* Introduced `AppointmentDao` entity representing appointments, with fields for user, officer, department, task, timing, status, urgency, notes, transfer history, and additional officers.
* Created `AppointmentRepository` with custom queries for retrieving appointments by user, officer, date, and status.
* Added request (`AppointmentRequestDTO`, `AppointmentActionRequestDTO`) and response (`AppointmentResponseDTO`) DTOs for appointment operations, including validation and structured info. 
* Defined `AppointmentStatus` enum to standardize appointment states (e.g., BOOKED, CONFIRMED, CANCELLED, etc.).

**Supporting Entities and Repositories**

* Added `DepartmentDao`, `OfficerDao`, and `TaskDao` entities to support appointments, each with relevant fields and relationships. 

**Address Entity Update**

* Relaxed validation and nullability constraints for `town`, `province`, and added optional `streetAddress` in the `Address` entity to accommodate incomplete address data.